### PR TITLE
Fixing issue with Input Tool Bar incorrectly re-sizing when shrinking…

### DIFF
--- a/Documentation/apps_using_this_library.md
+++ b/Documentation/apps_using_this_library.md
@@ -42,4 +42,5 @@ These are the (known) apps that use `JSQMessagesViewController`. Submit a [pull 
 * [Yellow Partner](https://itunes.apple.com/us/app/yellow-partner/id1062994361?ls=1&mt=8)
 * [Radiate](https://itunes.apple.com/us/app/radiate/id939284774?mt=8)
 * [Criptext](https://itunes.apple.com/us/app/criptext-secure-messenger/id848647361?mt=8)
+* [CareAware Connect](https://itunes.apple.com/us/app/id692368529)
 * *Your app here, submit a [pull request](https://github.com/jessesquires/JSQMessagesViewController/compare)!*

--- a/JSQMessagesTests/ViewTests/JSQMessagesInputToolbarTests.m
+++ b/JSQMessagesTests/ViewTests/JSQMessagesInputToolbarTests.m
@@ -67,4 +67,46 @@
     XCTAssertLessThanOrEqual(CGRectGetHeight(demoVC.inputToolbar.frame), 54, @"Toolbar height should be <= to maximumInputToolbarHeight");
 }
 
+/**
+ * Tests JSQMessagesInputToolbar
+ * Verifies 'atMaximumHeight' is set correctly
+ * Verifies 'maximumTextViewHeight is set correctly, asynchronously
+ */
+- (void)testLayoutSubviews
+{
+    JSQMessagesViewController *vc = [JSQMessagesViewController messagesViewController];
+    [vc loadView];
+    
+    JSQMessagesInputToolbar *toolbar = vc.inputToolbar;
+    toolbar.maximumHeight = toolbar.frame.size.height;
+    
+    [self keyValueObservingExpectationForObject:toolbar
+                                        keyPath:@"maximumTextViewHeight"
+                                  expectedValue:@(toolbar.contentView.textView.frame.size.height)];
+    
+    [toolbar layoutSubviews];
+    
+    XCTAssertTrue(toolbar.atMaximumHeight);
+    
+    [self waitForExpectationsWithTimeout:0.5 handler:nil];
+}
+
+/**
+ * Tests JSQMessagesInputToolbar
+ * Verifies 'atMaximumHeight' is set correctly
+ * Verifies 'maximumTextViewHeight is set correctly, asynchronously
+ */
+- (void)testLayoutSubviews_NotAtMax
+{
+    JSQMessagesViewController *vc = [JSQMessagesViewController messagesViewController];
+    [vc loadView];
+    
+    JSQMessagesInputToolbar *toolbar = vc.inputToolbar;
+    toolbar.maximumHeight = toolbar.frame.size.height+1;
+    
+    [toolbar layoutSubviews];
+    
+    XCTAssertFalse(toolbar.atMaximumHeight);
+}
+
 @end

--- a/JSQMessagesViewController/Views/JSQMessagesInputToolbar.h
+++ b/JSQMessagesViewController/Views/JSQMessagesInputToolbar.h
@@ -93,6 +93,16 @@
 @property (assign, nonatomic) NSUInteger maximumHeight;
 
 /**
+ * Whether the input view is currently at it's maximum height
+ */
+@property (assign, nonatomic, readonly) BOOL atMaximumHeight;
+
+/**
+ * Returns the maximum height reached by the text view
+ */
+@property (assign, nonatomic, readonly) NSUInteger maximumTextViewHeight;
+
+/**
  *  Enables or disables the send button based on whether or not its `textView` has text.
  *  That is, the send button will be enabled if there is text in the `textView`, and disabled otherwise.
  */

--- a/JSQMessagesViewController/Views/JSQMessagesInputToolbar.m
+++ b/JSQMessagesViewController/Views/JSQMessagesInputToolbar.m
@@ -32,6 +32,8 @@ static void * kJSQMessagesInputToolbarKeyValueObservingContext = &kJSQMessagesIn
 @interface JSQMessagesInputToolbar ()
 
 @property (assign, nonatomic) BOOL jsq_isObserving;
+@property (assign, nonatomic, readwrite) BOOL atMaximumHeight;
+@property (assign, nonatomic, readwrite) NSUInteger maximumTextViewHeight;
 
 @end
 
@@ -80,6 +82,21 @@ static void * kJSQMessagesInputToolbarKeyValueObservingContext = &kJSQMessagesIn
 - (void)dealloc
 {
     [self jsq_removeObservers];
+}
+
+#pragma mark - View Overrides
+
+-(void)layoutSubviews
+{
+    [super layoutSubviews];
+    
+    self.atMaximumHeight = (self.frame.size.height >= self.maximumHeight);
+    if(self.atMaximumHeight)
+    {
+        [[NSOperationQueue mainQueue] addOperationWithBlock:^{ //async, because the new height hasn't been fully calculated during the execution loop
+            self.maximumTextViewHeight = self.contentView.textView.frame.size.height;
+        }];
+    }
 }
 
 #pragma mark - Setters


### PR DESCRIPTION
… (#1864)

* Added new attributes to JSQMessagesInputToolbar to track maximum height info (account for full screen vs. limited)